### PR TITLE
Create create-postgresql-server.sh

### DIFF
--- a/postgresql/create-postgresql-server-vnet/create-postgresql-server.sh
+++ b/postgresql/create-postgresql-server-vnet/create-postgresql-server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Create a resource group
+az group create \
+--name myresourcegroup \
+--location westus
+
+# Create a PostgreSQL server in the resource group
+# Name of a server maps to DNS name and is thus required to be globally unique in Azure.
+# Substitute the <server_admin_password> with your own value.
+az postgres server create \
+--name mypgserver-20180111 \
+--resource-group myresourcegroup \
+--location westus \
+--admin-user mylogin \
+--admin-password <server_admin_password> \
+--performance-tier Standard \
+--compute-units 100


### PR DESCRIPTION
Need to create a standard tier for VNet service endpoints private preview. It does not support the Basic tier. This could still be the case for public preview. Will change the documentation to Basic once it is supported. Mbolz tested the script 1/11/2018 = pass.
{
  "administratorLogin": "mylogin",
  "fullyQualifiedDomainName": "mypgserver-20180111.postgres.database.azure.com",
  "id": "/subscriptions/0ffa90b2-4a7a-4952-9ca5-bbfd7d437d0f/resourceGroups/myresourcegroup/providers/Microsoft.DBforPostgreSQL/servers/mypgserver-20180111",
  "location": "westus",
  "name": "mypgserver-20180111",
  "resourceGroup": "myresourcegroup",
  "sku": {
    "capacity": 100,
    "family": null,
    "name": "PGSQLS100",
    "size": null,
    "tier": "Standard"
  },
  "sslEnforcement": "Enabled",
  "storageMb": 128000,
  "tags": null,
  "type": "Microsoft.DBforPostgreSQL/servers",
  "userVisibleState": "Ready",
  "version": "9.6"