### PR TITLE
Create mysql server for Vnet private preview

### DIFF
--- a/mysql/create-mysql-server-vnet/create-mysql-server.sh
+++ b/mysql/create-mysql-server-vnet/create-mysql-server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Create a resource group
+az group create \
+--name myresourcegroup \
+--location westus
+
+# Create a PostgreSQL server in the resource group
+# Name of a server maps to DNS name and is thus required to be globally unique in Azure.
+# Substitute the <server_admin_password> with your own value.
+az mysql server create \
+--name mypgserver-20180112 \
+--resource-group myresourcegroup \
+--location westus \
+--admin-user mylogin \
+--admin-password <server_admin_password> \
+--performance-tier Standard \
+--compute-units 100


### PR DESCRIPTION
Need to create standard tier mysql server for VNet service endpoint private preview. It does not support Basic Tier. This script creates a Standard Tier DB. Tested 1/12/2018 = Pass

{
  "administratorLogin": "mylogin",
  "fullyQualifiedDomainName": "mypgserver-20180111.mysql.database.azure.com",
  "id": "/subscriptions/0ffa90b2-4a7a-4952-9ca5-bbfd7d437d0f/resourceGroups/myresourcegroup/providers/Microsoft.DBforMySQL/servers/mypgserver-20180111",
  "location": "westus",
  "name": "mypgserver-20180111",
  "resourceGroup": "myresourcegroup",
  "sku": {
    "capacity": 100,
    "family": null,
    "name": "MYSQLS100",
    "size": null,
    "tier": "Standard"
  },
  "sslEnforcement": "Enabled",
  "storageMb": 128000,
  "tags": null,
  "type": "Microsoft.DBforMySQL/servers",
  "userVisibleState": "Ready",
  "version": "5.7"